### PR TITLE
Remove call do #delegate so we can run outside of Rails.

### DIFF
--- a/lib/rollout_ui/feature.rb
+++ b/lib/rollout_ui/feature.rb
@@ -4,8 +4,6 @@ module RolloutUi
 
     attr_reader :name
 
-    delegate :percentage_key, :group_key, :user_key, :to => :rollout
-
     def initialize(name)
       @wrapper = Wrapper.new
       @name = name
@@ -46,5 +44,11 @@ module RolloutUi
     def rollout
       @wrapper.rollout
     end
+
+    [:percentage_key, :group_key, :user_key].each do |method_name|
+      define_method(method_name) {|name| rollout.send(method_name, name)}
+    end
+
+
   end
 end


### PR DESCRIPTION
Running rollout_ui as a standalone Sinatra/Rack app would cause it to crash as it loaded features, because feature.rb used a method from ActiveSupport, which is not one of rollout_ui's runtime dependency.

I changed the Feature class to be independent of ActiveSupport, which should allow it to work in both modes without issue. No new tests were added, since the old tests cover the same functionality. I'm not sure how to test for this specific bug in the existing specs, since they require Rails.
