### PR TITLE
Support older versions of redis

### DIFF
--- a/lib/rollout_ui/feature.rb
+++ b/lib/rollout_ui/feature.rb
@@ -14,11 +14,11 @@ module RolloutUi
     end
 
     def groups
-      redis.smembers(group_key(name))
+      redis.smembers(group_key(name)) || []
     end
 
     def user_ids
-      redis.smembers(user_key(name))
+      redis.smembers(user_key(name)) || []
     end
 
     def percentage=(percentage)

--- a/lib/rollout_ui/wrapper.rb
+++ b/lib/rollout_ui/wrapper.rb
@@ -18,7 +18,8 @@ module RolloutUi
     end
 
     def features
-      redis.smembers(:features).sort
+      features = redis.smembers(:features)
+      features ? features.sort : []
     end
 
     def redis

--- a/spec/lib/rollout_ui/feature_spec.rb
+++ b/spec/lib/rollout_ui/feature_spec.rb
@@ -23,6 +23,12 @@ describe RolloutUi::Feature do
   end
 
   describe "#groups" do
+
+    it "returns an empty array when there are no activated groups for the feature" do
+      $redis.del('feature:featureA:groups')
+      @feature.groups.should == []
+    end
+
     it "returns the activated groups for the feature" do
       $rollout.activate_group(:featureA, :beta_testers)
       @feature.groups.should == ["beta_testers"]
@@ -37,6 +43,11 @@ describe RolloutUi::Feature do
   end
 
   describe "#users" do
+    it "returns an empty array when there are no activated users for the feature" do
+      $redis.del('=feature:featureA:users')
+      @feature.user_ids.should == []
+    end
+
     it "returns the activated users for the feature" do
       $rollout.activate_user(:featureA, mock(:user, :id => 5))
       @feature.user_ids.should == ["5"]


### PR DESCRIPTION
In previous versions of redis, calling commands operating on non-existent keys would return nil. This patch just ensures that we are always dealing with an array when we expect to do so.
