### PR TITLE
Add users by email or whatever

### DIFF
--- a/lib/rollout_ui.rb
+++ b/lib/rollout_ui.rb
@@ -22,4 +22,36 @@ module RolloutUi
   def self.rollout
     @@rollout
   end
+
+  def self.find_users_by(field)
+    @@user_name_field = field
+  end
+
+  def self.user_name_field
+    @@user_name_field ||= :id
+  end
+
+  def self.user_class=(user_class)
+    @@user_class = user_class
+  end
+
+  def self.user_class
+    @@user_class ||= User
+  end
+
+  def self.find_user_names(user_ids)
+    if @@user_name_field && user_ids.present?
+      user_class.where(id: user_ids).pluck(@@user_name_field)
+    else
+      user_ids
+    end
+  end
+
+  def self.find_user_ids(user_identifiers)
+    if @@user_name_field && user_identifiers.present?
+      user_class.where(@@user_name_field => user_identifiers).pluck(:id)
+    else
+      user_identifiers
+    end
+  end
 end

--- a/lib/rollout_ui/engine/app/assets/stylesheets/rollout_ui/layout.css
+++ b/lib/rollout_ui/engine/app/assets/stylesheets/rollout_ui/layout.css
@@ -61,7 +61,6 @@ h1 img {
 }
 
 #features .feature label {
-  float: left;
   font-size: 14px;
   line-height: 2em;
   color: #fcc334;

--- a/lib/rollout_ui/engine/app/assets/stylesheets/rollout_ui/layout.css
+++ b/lib/rollout_ui/engine/app/assets/stylesheets/rollout_ui/layout.css
@@ -60,10 +60,6 @@ h1 img {
   letter-spacing: 1px;
 }
 
-#features .feature .groups {
-  height: 1.5em;
-}
-
 #features .feature label {
   float: left;
   font-size: 14px;
@@ -88,6 +84,7 @@ h1 img {
 
 #features .feature .groups {
   width: 213px;
+  height: 1.5em;
 }
 
 #features .feature .chzn-container-multi .chzn-choices {

--- a/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
+++ b/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
@@ -11,7 +11,7 @@ module RolloutUi
 
       @feature.percentage = params["percentage"] if params["percentage"]
       @feature.groups     = params["groups"]     if params["groups"]
-      @feature.user_ids   = params["users"]      if params["users"]
+      @feature.user_names = params["user_names"] if params["user_names"]
 
       redirect_to features_path
     end

--- a/lib/rollout_ui/engine/app/views/rollout_ui/features/_feature.html.erb
+++ b/lib/rollout_ui/engine/app/views/rollout_ui/features/_feature.html.erb
@@ -27,8 +27,8 @@
 
 <div class="col">
   <%= form_tag feature_path(feature), :class => "users_form", :method => :put, :remote => true do %>
-    <label>Add User ID</label>
-    <input class="users" type="text" name="users[]" value="<%= feature.user_ids.join(",") %>" data-placeholder="Enter User ID" />
+    <label>Add User by <%= RolloutUi.user_name_field %></label>
+    <input class="users" type="text" name="user_names[]" value="<%= feature.user_names.join(",") %>" data-placeholder="Enter User <%= RolloutUi.user_name_field %>" />
     <input type="submit" value="Save" />
   <% end %>
 </div>

--- a/lib/rollout_ui/engine/app/views/rollout_ui/features/_feature.html.erb
+++ b/lib/rollout_ui/engine/app/views/rollout_ui/features/_feature.html.erb
@@ -1,7 +1,7 @@
 <h2><%= feature.name %></h2>
 
 <div class="col">
-  <%= form_tag feature_path(feature.name), :class => "percentage_form", :method => :put, :remote => true do %>
+  <%= form_tag feature_path(feature), :class => "percentage_form", :method => :put, :remote => true do %>
     <label>Percentage</label>
     <select class="percentage" name="percentage">
       <% 101.times do |i| %>
@@ -13,7 +13,7 @@
 </div>
 
 <div class="col">
-  <%= form_tag feature_path(feature.name), :class => "groups_form", :method => :put, :remote => true do %>
+  <%= form_tag feature_path(feature), :class => "groups_form", :method => :put, :remote => true do %>
     <label>Groups</label>
     <select id="<%= feature.name %>_groups" class="groups" name="groups[]" multiple="multiple" data-placeholder="Choose a group">
       <% @wrapper.groups.each do |group| %>
@@ -26,7 +26,7 @@
 </div>
 
 <div class="col">
-  <%= form_tag feature_path(feature.name), :class => "users_form", :method => :put, :remote => true do %>
+  <%= form_tag feature_path(feature), :class => "users_form", :method => :put, :remote => true do %>
     <label>Add User ID</label>
     <input class="users" type="text" name="users[]" value="<%= feature.user_ids.join(",") %>" data-placeholder="Enter User ID" />
     <input type="submit" value="Save" />

--- a/lib/rollout_ui/feature.rb
+++ b/lib/rollout_ui/feature.rb
@@ -39,6 +39,14 @@ module RolloutUi
       ids.each { |id| rollout.activate_user(name, User.new(id)) unless id.to_s.empty? }
     end
 
+    def user_names
+      RolloutUi.find_user_names(user_ids)
+    end
+
+    def user_names=(user_names)
+      self.user_ids = RolloutUi.find_user_ids(user_names)
+    end
+
   private
 
     def redis

--- a/lib/rollout_ui/feature.rb
+++ b/lib/rollout_ui/feature.rb
@@ -9,6 +9,10 @@ module RolloutUi
       @name = name
     end
 
+    def to_param
+      name
+    end
+
     def percentage
       redis.get(percentage_key(name))
     end

--- a/lib/rollout_ui/wrapper.rb
+++ b/lib/rollout_ui/wrapper.rb
@@ -1,6 +1,6 @@
 module RolloutUi
   class Wrapper
-    class NoRolloutInstance < StandardError; end
+    class NoRolloutInstance < ArgumentError; end
 
     attr_reader :rollout
 


### PR DESCRIPTION
This allows the user to set a field other than id for use in the third column.

The user calls: `RolloutUi.find_users_by(:email)`, and the email field is used to Users. The user can also set the target user class for this operation via `RolloutUi.user_class =`.

The changes would need to be carried over to the sinatra side as well before they're released, and there's room to debate over whether this is too general or not general enough a solution, but this is good enough for my purposes, so I submit it for your consideration.

There are also some minor incidental fixes included in this pull request, most notably: 5f1aa29
