### PR TITLE
Hooking wrong layout fix

### DIFF
--- a/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
+++ b/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
@@ -1,5 +1,5 @@
 module RolloutUi
-  class FeaturesController < ApplicationController
+  class FeaturesController < RolloutUi::ApplicationController
     before_filter :wrapper, :only => [:index]
 
     def index


### PR DESCRIPTION
I had an odd issue.
I've mounted rollout_ui like so:

``` ruby
mount RolloutUi::Engine => "/rolloutui", as: "rollout"
```

On my dev machine if i've started server and opened /rolloutui url first(before accessing any other url on my site) i have no problem, but if i've opened any site url before and tried to access /rolloutui afterwards then rollout_ui tried to hook my application layout instead of his own. Provided code fixes problem for me.

rails 3.2.3
ruby 1.9.3p194
