### PR TITLE
Make layout links protocol relative

### DIFF
--- a/lib/rollout_ui/server/views/layout.erb
+++ b/lib/rollout_ui/server/views/layout.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>RolloutUI</title>
-    <link href='http://fonts.googleapis.com/css?family=Ultra' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Ultra' rel='stylesheet' type='text/css'>
     <link href="<%=u 'rollout_ui/application.css' %>" media="screen" rel="stylesheet" type="text/css" />
   </head>
 
@@ -17,7 +17,7 @@
     </div>
   </body>
 
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js"></script>
+  <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js"></script>
   <script src="<%=u 'rollout_ui/application.js' %>" type="text/javascript"></script>
   <script type="text/javascript">
     $(function() {


### PR DESCRIPTION
This change should get rid of mixed content warnings when mounting rollout_ui behind https.

[More info from Paul Irish](http://paulirish.com/2010/the-protocol-relative-url/)
