### PR TITLE
Address deprecation warning regarding public_folder for Sinatra 1.3+

### DIFF
--- a/lib/rollout_ui/server.rb
+++ b/lib/rollout_ui/server.rb
@@ -13,8 +13,13 @@ module RolloutUi
     dir = File.dirname(File.expand_path(__FILE__))
 
     set :views,  "#{dir}/server/views"
-    set :public, "#{dir}/server/public"
     set :static, true
+
+    if respond_to? :public_folder
+      set :public_folder, "#{dir}/server/public"
+    else
+      set :public, "#{dir}/server/public"
+    end
 
     helpers do
       include Rack::Utils


### PR DESCRIPTION
This change should be a backward compatible fix for sinatra 1.3+ deprecation warning

`:public is no longer used to avoid overloading Module#public, use :public_folder instead`
