### PR TITLE
Rails Engine Should Use Protocol-Relative URLs

### DIFF
--- a/lib/rollout_ui/engine/app/views/layouts/rollout_ui/application.html.erb
+++ b/lib/rollout_ui/engine/app/views/layouts/rollout_ui/application.html.erb
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>RolloutUI</title>
-    <link href='http://fonts.googleapis.com/css?family=Ultra' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Ultra' rel='stylesheet' type='text/css'>
     <%= stylesheet_link_tag "rollout_ui/application" %>
     <%= csrf_meta_tags %>
   </head>
@@ -18,7 +18,7 @@
     </div>
   </body>
 
-  <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js"></script>
+  <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js"></script>
   <%= javascript_include_tag "rollout_ui/application" %>
 
   <script type="text/javascript">


### PR DESCRIPTION
Issue #12 fixed this issue for the standalone server, but the same problem exists in the Rails Engine.
