### PR TITLE
Fix monkey patch for Rollout 1.2.0

### DIFF
--- a/lib/rollout_ui/monkey_patch.rb
+++ b/lib/rollout_ui/monkey_patch.rb
@@ -1,7 +1,7 @@
 class Rollout
   alias_method :original_active?, :active?
 
-  def active?(feature, user)
+  def active?(feature, user=nil)
     RolloutUi::Wrapper.new(self).add_feature(feature)
     original_active?(feature, user)
   end

--- a/rollout_ui.gemspec
+++ b/rollout_ui.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir["spec/**/*"]
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency('rollout', '~> 1.1.0')
+  gem.add_runtime_dependency('rollout', '~> 1.1')
 
   gem.add_development_dependency('rake')
   gem.add_development_dependency('rails')


### PR DESCRIPTION
The latest Rollout makes the second argument of `active?` optional -- if
nil it checks if a feature is globally active. Adding the default to the
monkey patch should be backwards compatible with older versions of
Rollout for non-pathological cases since there is no arity change.
