### PR TITLE
Rollout 2.0 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'http://rubygems.org'
 
 # Specify your gem's dependencies in rollout_ui.gemspec
 gemspec
+
+gem 'rollout', github: 'jamesgolick/rollout'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,15 @@
+GIT
+  remote: git://github.com/jamesgolick/rollout.git
+  revision: 70973c95b38d751a690690b4f1ad7b8af8865f22
+  specs:
+    rollout (2.0.0c)
+      redis
+
 PATH
   remote: .
   specs:
     rollout_ui (0.2.0)
-      rollout (~> 1.1)
+      rollout
 
 GEM
   remote: http://rubygems.org/
@@ -62,7 +69,6 @@ GEM
       treetop (~> 1.4.8)
     mime-types (1.16)
     multi_json (1.0.3)
-    mysql (2.8.1)
     nokogiri (1.5.0)
     polyglot (0.3.2)
     rack (1.3.4)
@@ -95,8 +101,6 @@ GEM
     redis (2.2.2)
     redis-namespace (1.0.3)
       redis (< 3.0.0)
-    rollout (1.2.0)
-      redis
     rspec (2.6.0)
       rspec-core (~> 2.6.0)
       rspec-expectations (~> 2.6.0)
@@ -141,11 +145,11 @@ PLATFORMS
 DEPENDENCIES
   capybara
   launchy
-  mysql
   rack-test
   rails
   rake
   redis-namespace
+  rollout!
   rollout_ui!
   rspec-rails
   sinatra

--- a/lib/rollout_ui/feature.rb
+++ b/lib/rollout_ui/feature.rb
@@ -26,10 +26,12 @@ module RolloutUi
     end
 
     def groups=(groups)
+      self.groups.each { |group| rollout.deactivate_group(name, group) }
       groups.each { |group| rollout.activate_group(name, group) unless group.to_s.empty? }
     end
 
     def user_ids=(ids)
+      self.user_ids.each { |id| rollout.deactivate_user(name, User.new(id)) unless id.to_s.empty? }
       ids.each { |id| rollout.activate_user(name, User.new(id)) unless id.to_s.empty? }
     end
 

--- a/lib/rollout_ui/wrapper.rb
+++ b/lib/rollout_ui/wrapper.rb
@@ -23,7 +23,7 @@ module RolloutUi
     end
 
     def redis
-      rollout.instance_variable_get("@redis")
+      rollout.instance_variable_get("@storage")
     end
   end
 end

--- a/rollout_ui.gemspec
+++ b/rollout_ui.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = Dir["spec/**/*"]
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency('rollout', '~> 1.1')
+  gem.add_runtime_dependency('rollout')
 
   gem.add_development_dependency('rake')
   gem.add_development_dependency('rails')

--- a/rollout_ui.gemspec
+++ b/rollout_ui.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rails')
   gem.add_development_dependency('sinatra')
   gem.add_development_dependency('uglifier')
-  gem.add_development_dependency('mysql')
   gem.add_development_dependency('rspec-rails')
   gem.add_development_dependency('capybara')
   gem.add_development_dependency('launchy')

--- a/spec/lib/rollout_ui/feature_spec.rb
+++ b/spec/lib/rollout_ui/feature_spec.rb
@@ -31,14 +31,14 @@ describe RolloutUi::Feature do
 
     it "returns the activated groups for the feature" do
       $rollout.activate_group(:featureA, :beta_testers)
-      @feature.groups.should == ["beta_testers"]
+      @feature.groups.should == [:beta_testers]
     end
   end
 
   describe "#groups=" do
     it "sets the activated groups for the feature" do
       @feature.groups = ["all", "admins"]
-      RolloutUi::Feature.new(:featureA).groups.should == ["admins", "all"]
+      RolloutUi::Feature.new(:featureA).groups.should =~ [:admins, :all]
     end
   end
 

--- a/spec/lib/rollout_ui/wrapper_spec.rb
+++ b/spec/lib/rollout_ui/wrapper_spec.rb
@@ -23,13 +23,13 @@ describe RolloutUi::Wrapper do
     it "returns all groups defined for the rollout instance" do
       $rollout.define_group(:beta_testers) { |user| user.beta_tester? }
 
-      @rollout_ui.groups.should == ["all", "beta_testers"]
+      @rollout_ui.groups.should == [:all, :beta_testers]
     end
 
     it "doesn't return other defined groups" do
       Rollout.new($redis).define_group(:beta_testers) { |user| user.beta_tester? }
 
-      @rollout_ui.groups.should == ["all"]
+      @rollout_ui.groups.should == [:all]
     end
   end
 


### PR DESCRIPTION
- It drops support for rollout 1.x.x.
- The user must require rollout 2.0 explicitly, as it needs to be required through bundler, at least until 2.0 is officially released.
