### PR TITLE
Delegates features list request to rollout

### DIFF
--- a/lib/rollout_ui/wrapper.rb
+++ b/lib/rollout_ui/wrapper.rb
@@ -3,6 +3,7 @@ module RolloutUi
     class NoRolloutInstance < StandardError; end
 
     attr_reader :rollout
+    delegate :features, to: :rollout
 
     def initialize(rollout = nil)
       @rollout = rollout || RolloutUi.rollout
@@ -15,11 +16,6 @@ module RolloutUi
 
     def add_feature(feature)
       redis.sadd(:features, feature)
-    end
-
-    def features
-      features = redis.smembers(:features)
-      features ? features.sort : []
     end
 
     def redis


### PR DESCRIPTION
`#features` was returning an empty array on my app - I'm setting it up from scratch with the latest version of rollout. 

I noticed `$rollout` does actually have a shortcut for its features, so I'm delegating the wrapper's call to rollout instead of relying on its own separate implementation, fixes my problem. :) 
