### PR TITLE
MonkeyPatch: don't write feature if it already exists.

### DIFF
--- a/lib/rollout_ui/monkey_patch.rb
+++ b/lib/rollout_ui/monkey_patch.rb
@@ -2,7 +2,11 @@ class Rollout
   alias_method :original_active?, :active?
 
   def active?(feature, user=nil)
-    RolloutUi::Wrapper.new(self).add_feature(feature)
+    ui_wrapper.add_feature(feature) unless ui_wrapper.feature_exists?(feature)
     original_active?(feature, user)
+  end
+
+  def ui_wrapper
+    RolloutUi::Wrapper.new(self)
   end
 end

--- a/lib/rollout_ui/monkey_patch.rb
+++ b/lib/rollout_ui/monkey_patch.rb
@@ -7,6 +7,6 @@ class Rollout
   end
 
   def ui_wrapper
-    RolloutUi::Wrapper.new(self)
+    @_wrapper ||= RolloutUi::Wrapper.new(self)
   end
 end

--- a/lib/rollout_ui/wrapper.rb
+++ b/lib/rollout_ui/wrapper.rb
@@ -22,6 +22,10 @@ module RolloutUi
       features ? features.sort : []
     end
 
+    def feature_exists?(feature)
+      features.include?(feature.to_s)
+    end
+
     def redis
       rollout.instance_variable_get("@storage")
     end

--- a/spec/lib/monkey_patch_spec.rb
+++ b/spec/lib/monkey_patch_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Rollout do
+  describe "getting the active state" do
+    before do
+      @wrapper = $rollout.ui_wrapper
+    end
+
+    it "adds a feature if it doesn't exist yet" do
+      @wrapper.should_receive(:feature_exists?).once.and_return(false)
+      @wrapper.should_receive(:add_feature).once.with(:new_feature)
+
+      $rollout.active?(:new_feature)
+    end
+
+    it "doesn't add a new feature if it already exists" do
+      @wrapper.should_receive(:feature_exists?).once.and_return(true)
+      @wrapper.should_receive(:add_feature).never
+
+      $rollout.active?(:new_feature)
+    end
+  end
+end

--- a/spec/lib/rollout_ui/wrapper_spec.rb
+++ b/spec/lib/rollout_ui/wrapper_spec.rb
@@ -62,6 +62,20 @@ describe RolloutUi::Wrapper do
     end
   end
 
+  describe "#feature_exists?" do
+    it "returns false if a feature doesn't exist" do
+      $rollout.active?(:featureA, mock(:user, :id => 1))
+
+      @rollout_ui.feature_exists?(:unexistingFeature).should eq false
+    end
+
+    it "returns true if a feature exists" do
+      $rollout.active?(:featureA, mock(:user, :id => 2))
+
+      @rollout_ui.feature_exists?(:featureA).should eq true
+    end
+  end
+
   describe "#add_feature" do
     it "adds feature to the list of features" do
       @rollout_ui.add_feature(:featureA)


### PR DESCRIPTION
Always writing is causing errors when you're using Rollout in a case
where you want certain parts to only read from slaves and other parts to
only write to your master.

As we're overwriting the standard `Rollout.active?` class, checking for
the `active` state in a read-only slave would cause a Redis error. Only
writing this feature when it doesn't exist resolves this issue.
