### PR TITLE
Add features from UI

### DIFF
--- a/lib/rollout_ui/engine/app/assets/stylesheets/rollout_ui/layout.css
+++ b/lib/rollout_ui/engine/app/assets/stylesheets/rollout_ui/layout.css
@@ -30,6 +30,10 @@ h1 img {
   padding: 0 25px;
 }
 
+.add-feature {
+  margin: 30px 0;
+}
+
 #container {
   width: 960px;
   margin: 0 auto;

--- a/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
+++ b/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
@@ -1,9 +1,15 @@
 module RolloutUi
   class FeaturesController < RolloutUi::ApplicationController
-    before_filter :wrapper, :only => [:index]
+    before_filter :wrapper, :only => [:index, :create]
 
     def index
       @features = @wrapper.features.map{ |feature| RolloutUi::Feature.new(feature) }
+    end
+
+    def create
+      @wrapper.add_feature(params[:name])
+
+      redirect_to features_path
     end
 
     def update

--- a/lib/rollout_ui/engine/app/views/rollout_ui/features/index.html.erb
+++ b/lib/rollout_ui/engine/app/views/rollout_ui/features/index.html.erb
@@ -1,3 +1,10 @@
+<div class="add-feature">
+  <%= form_tag "/rollout/features" do %>
+    <input name="name"></input>
+    <button>Add Feature</button>
+  <% end %>
+</div>
+
 <ul id="features">
   <% @features.each do |feature| %>
     <li id="<%= feature.name %>" class="feature clearfix"><%= render 'feature', :feature => feature %></li>

--- a/lib/rollout_ui/engine/app/views/rollout_ui/features/index.html.erb
+++ b/lib/rollout_ui/engine/app/views/rollout_ui/features/index.html.erb
@@ -1,15 +1,15 @@
-<div class="add-feature">
-  <%= form_tag "/rollout/features" do %>
-    <input name="name"></input>
-    <button>Add Feature</button>
-  <% end %>
-</div>
-
 <ul id="features">
   <% @features.each do |feature| %>
     <li id="<%= feature.name %>" class="feature clearfix"><%= render 'feature', :feature => feature %></li>
   <% end %>
 </ul>
+
+<div class="add-feature">
+  <%= form_tag features_path do %>
+    <input name="name" placeholder="feature_name"></input>
+    <button>Add Feature</button>
+  <% end %>
+</div>
 
 <% content_for :onready do %>
   $("select").chosen({no_results_text: "No groups matched"});

--- a/lib/rollout_ui/engine/config/routes.rb
+++ b/lib/rollout_ui/engine/config/routes.rb
@@ -1,5 +1,5 @@
 RolloutUi::Engine.routes.draw do
-  resources :features, :only => [:index, :update]
+  resources :features, :only => [:index, :create, :update]
 
   root :to => "features#index"
 end

--- a/spec/requests/engine/engine_spec.rb
+++ b/spec/requests/engine/engine_spec.rb
@@ -14,6 +14,19 @@ describe "Engine" do
       page.should have_content("featureA")
     end
 
+    describe "adding a feature" do
+      it "displays the added feature in the UI" do
+        visit "/rollout"
+
+        within(".add-feature") do
+          fill_in "name", with: "featureB"
+          click_button "Add Feature"
+        end
+
+        page.should have_content("featureB")
+      end
+    end
+
     describe "percentage" do
       it "allows changing of the percentage" do
         visit "/rollout"


### PR DESCRIPTION
In the case where RolloutUI is used in a system that eager loads enabled features for a user rather than asking whether a specific feature is enabled, developers can only create features through some sort of back-end mechanism like through the Rails console or a rake task.

This pull gives admins/developers the ability to add features directly from the Rollout UI, making it way easier to add features for such a system mentioned above.
