### PR TITLE
Add and remove features from the UI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    rollout_ui (0.2.0)
+    rollout_ui (0.3.0)
       rollout
 
 GEM

--- a/lib/rollout_ui/engine/app/assets/stylesheets/rollout_ui/layout.css
+++ b/lib/rollout_ui/engine/app/assets/stylesheets/rollout_ui/layout.css
@@ -30,6 +30,10 @@ h1 img {
   padding: 0 25px;
 }
 
+.add-feature {
+  margin: 30px 0;
+}
+
 #container {
   width: 960px;
   margin: 0 auto;

--- a/lib/rollout_ui/engine/app/assets/stylesheets/rollout_ui/layout.css
+++ b/lib/rollout_ui/engine/app/assets/stylesheets/rollout_ui/layout.css
@@ -52,12 +52,28 @@ h1 img {
   margin-bottom: 25px;
 }
 
+#features .feature header {
+  display: -webkit-box;
+  display: -moz-box;
+  display: box;
+  display: flex;
+}
+
 #features .feature h2 {
-  margin: 0px 0 23px;
-  text-align: center;
+  display: flex;
   font-size: 20px;
-  font-weight: normal;
-  letter-spacing: 1px;
+  -webkit-box-flex: 1;
+  -moz-box-flex: 1;
+  box-flex: 1;
+  -webkit-flex: 1;
+  -moz-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+  padding: 0 25px;
+}
+
+#features .feature nav {
+  padding: 20px 29px;
 }
 
 #features .feature .groups {

--- a/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
+++ b/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
@@ -1,9 +1,15 @@
 module RolloutUi
   class FeaturesController < RolloutUi::ApplicationController
-    before_filter :wrapper, :only => [:index, :destroy]
+    before_filter :wrapper, :only => [:index, :create, :destroy]
 
     def index
       @features = @wrapper.features.map{ |feature| RolloutUi::Feature.new(feature) }
+    end
+
+    def create
+      @wrapper.add_feature(params[:name])
+
+      redirect_to features_path
     end
 
     def update

--- a/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
+++ b/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
@@ -1,6 +1,6 @@
 module RolloutUi
   class FeaturesController < RolloutUi::ApplicationController
-    before_filter :wrapper, :only => [:index]
+    before_filter :wrapper, :only => [:index, :destroy]
 
     def index
       @features = @wrapper.features.map{ |feature| RolloutUi::Feature.new(feature) }
@@ -12,6 +12,12 @@ module RolloutUi
       @feature.percentage = params["percentage"] if params["percentage"]
       @feature.groups     = params["groups"]     if params["groups"]
       @feature.user_ids   = params["users"]      if params["users"]
+
+      redirect_to features_path
+    end
+
+    def destroy
+      @wrapper.remove_feature(params[:id])
 
       redirect_to features_path
     end

--- a/lib/rollout_ui/engine/app/views/rollout_ui/features/_feature.html.erb
+++ b/lib/rollout_ui/engine/app/views/rollout_ui/features/_feature.html.erb
@@ -1,4 +1,12 @@
-<h2><%= feature.name %></h2>
+<header class="feature-header">
+  <h2><%= feature.name %></h2>
+
+  <nav>
+    <%= form_tag feature_path(feature.name), method: :delete do %>
+      <button>remove</button>
+    <% end %>
+  </nav>
+</header>
 
 <div class="col">
   <%= form_tag feature_path(feature.name), :class => "percentage_form", :method => :put, :remote => true do %>

--- a/lib/rollout_ui/engine/app/views/rollout_ui/features/index.html.erb
+++ b/lib/rollout_ui/engine/app/views/rollout_ui/features/index.html.erb
@@ -4,6 +4,13 @@
   <% end %>
 </ul>
 
+<div class="add-feature">
+  <%= form_tag features_path do %>
+    <input name="name" placeholder="feature_name"></input>
+    <button>Add Feature</button>
+  <% end %>
+</div>
+
 <% content_for :onready do %>
   $("select").chosen({no_results_text: "No groups matched"});
   $("input.users").chosen();

--- a/lib/rollout_ui/engine/config/routes.rb
+++ b/lib/rollout_ui/engine/config/routes.rb
@@ -1,5 +1,5 @@
 RolloutUi::Engine.routes.draw do
-  resources :features, :only => [:index, :update]
+  resources :features, :only => [:index, :update, :destroy]
 
   root :to => "features#index"
 end

--- a/lib/rollout_ui/engine/config/routes.rb
+++ b/lib/rollout_ui/engine/config/routes.rb
@@ -1,5 +1,5 @@
 RolloutUi::Engine.routes.draw do
-  resources :features, :only => [:index, :update, :destroy]
+  resources :features, :only => [:index, :create, :update, :destroy]
 
   root :to => "features#index"
 end

--- a/lib/rollout_ui/wrapper.rb
+++ b/lib/rollout_ui/wrapper.rb
@@ -17,6 +17,10 @@ module RolloutUi
       redis.sadd(:features, feature)
     end
 
+    def remove_feature(feature)
+      redis.srem(:features, feature)
+    end
+
     def features
       features = redis.smembers(:features)
       features ? features.sort : []

--- a/spec/lib/rollout_ui/wrapper_spec.rb
+++ b/spec/lib/rollout_ui/wrapper_spec.rb
@@ -69,4 +69,14 @@ describe RolloutUi::Wrapper do
       @rollout_ui.features.should == ["featureA"]
     end
   end
+
+  describe "#remove_feature" do
+    it "adds feature to the list of features" do
+      @rollout_ui.add_feature(:feature)
+
+      @rollout_ui.remove_feature(:feature)
+
+      @rollout_ui.features.should == []
+    end
+  end
 end

--- a/spec/lib/rollout_ui/wrapper_spec.rb
+++ b/spec/lib/rollout_ui/wrapper_spec.rb
@@ -71,7 +71,7 @@ describe RolloutUi::Wrapper do
   end
 
   describe "#remove_feature" do
-    it "adds feature to the list of features" do
+    it "removes a feature from the list of features" do
       @rollout_ui.add_feature(:feature)
 
       @rollout_ui.remove_feature(:feature)

--- a/spec/requests/engine/engine_spec.rb
+++ b/spec/requests/engine/engine_spec.rb
@@ -14,6 +14,18 @@ describe "Engine" do
       page.should have_content("featureA")
     end
 
+    describe "remove button" do
+      it "removes the feature" do
+        visit "/rollout"
+
+        within("#featureA .feature-header") do
+          click_button "remove"
+        end
+
+        $rollout.active?(:featureA, user).should be_false
+      end
+    end
+
     describe "percentage" do
       it "allows changing of the percentage" do
         visit "/rollout"

--- a/spec/requests/engine/engine_spec.rb
+++ b/spec/requests/engine/engine_spec.rb
@@ -116,6 +116,19 @@ describe "Engine" do
         page.body.should =~ Regexp.new("#{elements.join('.*')}.*", Regexp::MULTILINE)
       end
     end
+
+    describe "adding a feature" do
+      it "displays the added feature in the UI" do
+        visit "/rollout"
+
+        within(".add-feature") do
+          fill_in "name", with: "featureB"
+          click_button "Add Feature"
+        end
+
+        page.should have_content("featureB")
+      end
+    end
   end
 end
 


### PR DESCRIPTION
### Adding features from the UI

In the case where RolloutUI is used in a system that eager loads enabled features for a user rather than asking whether a specific feature is enabled, developers can only create features through some sort of back-end mechanism like through the Rails console or a rake task.

This pull gives admins/developers the ability to add features directly from the Rollout UI, making it way easier to add features for such a system mentioned above.
### Remove features from the UI

When a feature toggle is no longer necessary for a given feature, there is no way to clean up these features from the UI, let alone some back end mechanism.

This pull gives admins/developers the ability to remove features directly from the Rollout UI which will help keep our indexes clean.
