### PR TITLE
Allow configuration of feature tracking

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -54,6 +54,15 @@ Put this somewhere before the `URLMap` in your `config.ru`:
       username == '<some username>' && password == '<some password>'
     end
 
+Configuration
+-------------
+
+By default, RolloutUI will attempt to take notice of new features that are not
+yet enabled. This behavior requires the use of redis as a backend to rollout. If
+you are using a different backend, you should disable this feature:
+
+`RolloutUi.track_features = false`
+
 Resources
 ---------
 

--- a/lib/rollout_ui.rb
+++ b/lib/rollout_ui.rb
@@ -21,4 +21,14 @@ module RolloutUi
   def self.rollout
     @@rollout
   end
+
+  def self.track_features=(value)
+    @@track_features = value
+  end
+
+  def self.track_features
+    @@track_features
+  end
+  self.track_features = true
+
 end

--- a/lib/rollout_ui/monkey_patch.rb
+++ b/lib/rollout_ui/monkey_patch.rb
@@ -2,7 +2,7 @@ class Rollout
   alias_method :original_active?, :active?
 
   def active?(feature, user=nil)
-    RolloutUi::Wrapper.new(self).add_feature(feature)
+    RolloutUi::Wrapper.new(self).add_feature(feature) if RolloutUi.track_features
     original_active?(feature, user)
   end
 end

--- a/lib/rollout_ui/wrapper.rb
+++ b/lib/rollout_ui/wrapper.rb
@@ -18,7 +18,12 @@ module RolloutUi
     end
 
     def features
-      features = redis.smembers(:features)
+      features =
+        if RolloutUi.track_features
+          redis.smembers(:features)
+        else
+          rollout.features
+        end
       features ? features.sort : []
     end
 

--- a/spec/lib/rollout_ui/wrapper_spec.rb
+++ b/spec/lib/rollout_ui/wrapper_spec.rb
@@ -60,6 +60,16 @@ describe RolloutUi::Wrapper do
 
       @rollout_ui.features.should == %w(anotherFeature featureA featureB zFeature)
     end
+
+    context "with feature tracking disabled" do
+      before(:all) { RolloutUi.track_features = false }
+      after(:all)  { RolloutUi.track_features = true }
+
+      it "should not notice new features" do
+        $rollout.active?(:featureA)
+        @rollout_ui.features.should == []
+      end
+    end
   end
 
   describe "#add_feature" do


### PR DESCRIPTION
Feature tracking requires smembers which is only available when using redis
as a rollout backend. Allow it to be disabled when using a different backend.
