### PR TITLE
Add option to add a basic auth on rails engine

### DIFF
--- a/lib/rollout_ui.rb
+++ b/lib/rollout_ui.rb
@@ -21,4 +21,15 @@ module RolloutUi
   def self.rollout
     @@rollout
   end
+
+  def self.setup(&block)
+    @@config ||= RolloutUi::Engine::Configuration.new
+    yield @@config if block
+    return @@config
+  end
+
+  def self.config
+    Rails.application.config
+  end
+
 end

--- a/lib/rollout_ui/engine/app/controllers/rollout_ui/application_controller.rb
+++ b/lib/rollout_ui/engine/app/controllers/rollout_ui/application_controller.rb
@@ -1,4 +1,8 @@
 module RolloutUi
   class ApplicationController < ActionController::Base
+    user, password = RolloutUi.config.rails_user, RolloutUi.config.rails_password
+    if user && password
+      http_basic_authenticate_with name: user, password: password
+    end
   end
 end


### PR DESCRIPTION
This PR simple add a way to do basic auth in a Rails app, like explained on #23.

To use only setup it on a initializer:

```
RolloutUi.setup do |config|
  config.rails_user  = "user"
  config.rails_password  = "password"
end
```
