### PR TITLE
Add compatibility with rollout >= 2.2.1

### DIFF
--- a/lib/rollout_ui/feature.rb
+++ b/lib/rollout_ui/feature.rb
@@ -18,7 +18,7 @@ module RolloutUi
     end
 
     def user_ids
-      rollout.get(feature_for(name)).users
+      rollout.get(feature_for(name)).users.to_a
     end
 
     def percentage=(percentage_val)


### PR DESCRIPTION
When using `rollout >= 2.2.1`, a view breaks because of `Set` usage instead of `Array`. 
Solves #35 
