### PR TITLE
Add rollout.png to engine's precompiled assets

### DIFF
--- a/lib/rollout_ui/engine/lib/rollout_ui/engine.rb
+++ b/lib/rollout_ui/engine/lib/rollout_ui/engine.rb
@@ -1,5 +1,9 @@
 module RolloutUi
   class Engine < Rails::Engine
     isolate_namespace RolloutUi
+
+    initializer 'rollout_ui.assets.precompile' do |app|
+      app.config.assets.precompile += %w(rollout_ui/rollout.png)
+    end
   end
 end


### PR DESCRIPTION
- Fixes breaking changes with Rails 4 (or more likely Sprockets)