### PR TITLE
Fix Rollout UI for Rails 5

### DIFF
--- a/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
+++ b/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
@@ -1,6 +1,6 @@
 module RolloutUi
   class FeaturesController < RolloutUi::ApplicationController
-    before_filter :wrapper, :only => [:index]
+    before_action :wrapper, :only => [:index]
 
     def index
       @features = @wrapper.features.map{ |feature| RolloutUi::Feature.new(feature) }

--- a/lib/rollout_ui/engine/lib/rollout_ui/engine.rb
+++ b/lib/rollout_ui/engine/lib/rollout_ui/engine.rb
@@ -1,5 +1,9 @@
 module RolloutUi
   class Engine < Rails::Engine
     isolate_namespace RolloutUi
+    
+    initializer 'rollout_ui.assets.precompile' do |app|
+      app.config.assets.precompile += %w(rollout_ui/rollout.png)
+    end
   end
 end


### PR DESCRIPTION
- Fix asset precompilation
- Replace `before_filter` with `before_action` since `before_filter` is deprecated on Rails 5.0 and removed on Rails 5.1