### PR TITLE
Correctly display the selected feature percentage

### DIFF
--- a/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
+++ b/lib/rollout_ui/engine/app/controllers/rollout_ui/features_controller.rb
@@ -1,6 +1,6 @@
 module RolloutUi
   class FeaturesController < RolloutUi::ApplicationController
-    before_filter :wrapper, :only => [:index]
+    before_action :wrapper, :only => [:index]
 
     def index
       @features = @wrapper.features.map{ |feature| RolloutUi::Feature.new(feature) }

--- a/lib/rollout_ui/engine/app/views/rollout_ui/features/_feature.html.erb
+++ b/lib/rollout_ui/engine/app/views/rollout_ui/features/_feature.html.erb
@@ -5,7 +5,7 @@
     <label>Percentage</label>
     <select class="percentage" name="percentage">
       <% 101.times do |i| %>
-        <option value="<%= i %>"<%= " selected='selected'" if feature.percentage == i.to_s %>><%= i %>%</option>
+        <option value="<%= i %>"<%= " selected='selected'" if feature.percentage.to_i == i %>><%= i %>%</option>
       <% end %>
     </select>
     <input type="submit" value="Save" />


### PR DESCRIPTION
related to #35 

Since rollout >= 2.1 percentages can be floats:
https://github.com/fetlife/rollout/commit/ac5f55bfd5aea59bf7c4c9cea189cacd49b7d290
so we have to cast the float string to integer to mark the correct option as selected.

